### PR TITLE
Whitelist some more actions for automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,9 @@
         "/.*lint.*/",
         "/.*dockle.*/",
         "/.*trivy.*/",
-        "/.*anchore.*/"
+        "/.*anchore.*/",
+        "/.*scan.*/",
+        "/.*sarif.*/"
       ]
     }
   ]


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add actions/cache (v2, v3), actions/setup-node (v1, v2), and actions/checkout (v2) to Renovate's automerge whitelist