### PR TITLE
fix: add debugging to Docker image test step

### DIFF
--- a/.github/workflows/docker.image.yml
+++ b/.github/workflows/docker.image.yml
@@ -130,10 +130,17 @@ jobs:
           docker buildx imagetools inspect localhost:5000/foobar/${{ env.IMAGE_NAME }}
       - name: Test the Docker image
         run: |
-          CONTAINER_OUTPUT=$(docker run --rm -t localhost:5000/foobar/${{ env.IMAGE_NAME }} garbd -h | grep ^Usage)
-          # shellcheck disable=SC2086
-          TEST_STRING=$(echo ${CONTAINER_OUTPUT} | cut -d' ' -f2)
-          if ! [ "${TEST_STRING}" = "garbd" ]; then echo "${TEST_STRING} is not even 'garbd'"; exit 1; fi
+          CONTAINER_OUTPUT=$(docker run --rm localhost:5000/foobar/${{ env.IMAGE_NAME }} garbd -h 2>&1| grep ^Usage)
+          echo "Container output: $CONTAINER_OUTPUT"
+          echo "Container output (quoted): '$CONTAINER_OUTPUT'"
+
+          TEST_STRING=$(echo "${CONTAINER_OUTPUT}" | head -1 | cut -d' ' -f2)
+          echo "Extracted test string: '$TEST_STRING'"
+
+          if ! [ "${TEST_STRING}" = "garbd" ]; then
+            echo "ERROR: Expected 'garbd' but got '$TEST_STRING'"
+            exit 1
+          fi
   dockle:
     name: Run Dockle tests
     needs:


### PR DESCRIPTION
## Summary by Sourcery

Improve the Docker image test step in the CI workflow to validate the correct binary and provide clearer diagnostic output when the check fails.

CI:
- Update the Docker image test command in the GitHub Actions workflow to check for the expected 'garb' binary and print detailed debugging output on failures.

Tests:
- Adjust the image verification logic in the Docker workflow test step to parse the usage output more robustly and assert the correct binary name.